### PR TITLE
Create email & password validators w/ tests

### DIFF
--- a/evergreen/eg_app/tests.py
+++ b/evergreen/eg_app/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/evergreen/eg_app/tests/util/test_validators.py
+++ b/evergreen/eg_app/tests/util/test_validators.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from eg_app.util.validators import validate_email, validate_password
+
+# c-spell:disable - Don't spellcheck the emails
+
+class TestValidateEmail(TestCase):
+
+    def test_not_buffalo_email(self):
+        self.assertFalse(validate_email("username@gmail.com"))
+
+    def test_subdomain(self):
+        self.assertTrue(validate_email("username@dcsl.buffalo.edu"))
+
+    def test_deliverability(self):
+        self.assertTrue(validate_email("username@buffalo.edu", True))
+        self.assertTrue(validate_email("username@dcsl.buffalo.edu", True))
+        self.assertFalse(validate_email("username@notreal.buffalo.edu", True))
+
+    def test_valid_ubits(self):
+        self.assertTrue(validate_email("abcd@buffalo.edu"))
+        self.assertTrue(validate_email("longname@buffalo.edu"))
+        self.assertTrue(validate_email("alfanum1@buffalo.edu"))
+        self.assertTrue(validate_email("lt12@buffalo.edu"))
+        self.assertTrue(validate_email("hello123@buffalo.edu"))
+
+    def test_invalid_ubits(self):
+        self.assertFalse(validate_email("abc@buffalo.edu"))
+        self.assertFalse(validate_email("ninechars@buffalo.edu"))
+        self.assertFalse(validate_email("1numfrst@buffalo.edu"))
+        self.assertFalse(validate_email("mid4num@buffalo.edu"))
+        self.assertFalse(validate_email("symbols!@buffalo.edu"))
+        self.assertFalse(validate_email("123456@buffalo.edu"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(validate_email("VALID@BUFFALO.EDU"))
+
+
+class TestValidatePassword(TestCase):
+
+    def test_too_short(self):
+        self.assertFalse(validate_password("EightChr"))
+        self.assertFalse(validate_password("ElevenChars"))
+
+    def test_too_long(self):
+        self.assertFalse(validate_password("a" * 256))
+
+    def test_valid_passwords(self):
+        self.assertTrue(validate_password("TwelveChars1"))
+        self.assertTrue(validate_password("correcthorsebatterystaple"))
+        self.assertTrue(validate_password("123456789012"))
+        self.assertTrue(validate_password("NotANumberToBeSeen"))
+        self.assertTrue(validate_password("notevenlowercase"))
+        self.assertTrue(validate_password("all the symbols `~!@#$%^&*())-=_+[]{}\\|;',./:\"<>?"))
+        self.assertTrue(validate_password("a" * 12))
+        self.assertTrue(validate_password("1" * 12))
+        self.assertTrue(validate_password("A" * 255))
+

--- a/evergreen/eg_app/util/validators.py
+++ b/evergreen/eg_app/util/validators.py
@@ -1,0 +1,50 @@
+import email_validator as ev
+import re
+
+def validate_email(email: str, check_deliverability=False) -> bool:
+    """ Checks if the given email passes validation requirements
+
+    Validation requirements:
+    - Valid University at Buffalo email only
+      - User is comprised of letters followed by optional numbers
+      - User is 4-8 chars, inclusive
+      - Server is (optional subdomain).buffalo.edu
+
+    :param email: The email addresses from the user to validate
+    :param check_deliverability: Whether or not to perform a DNS query to see  \
+    if the domain can receive mail. Recommended to use `True` on registration, \
+    `False` on regular login. See https://pypi.org/project/email-validator/
+    
+    :returns: `True` if the email address passes requirements, `False` otherwise
+    """
+
+    try:
+      email_info = ev.validate_email(email, check_deliverability=check_deliverability)
+
+      local = email_info.local_part
+      domain = email_info.domain
+
+      l_len = 4 <= len(local) and len(local) <= 8
+      # If the local part (before the @) is [4-8] characters long, inclusive
+      l_match = re.match(r"^[a-z]+[0-9]*$", local, re.I) != None
+      # If the local part (before the @) is exactly a valid UBIT name
+      d_match = re.match(r"^(?:[a-z]*\.)?buffalo\.edu$", string=domain) != None
+      # If the domain (after the @) is exactly (optional subdomain).buffalo.edu
+
+      return l_len and l_match and d_match
+      
+    except ev.EmailNotValidError as e:
+      return False
+
+def validate_password(password: str) -> bool:
+    """ Checks if the given password passes validation requirements
+
+    Validation requirements:
+    - Length between 12 and 255 chars (inclusive)
+
+    :param password: The password from the user to validate
+    
+    :returns: `True` if the password passes requirements, `False` otherwise
+    """
+
+    return 12 <= len(password) and len(password) < 256

--- a/evergreen/requirements.txt
+++ b/evergreen/requirements.txt
@@ -4,3 +4,4 @@ Django
 pymongo 
 bcrypt
 whitenoise
+email-validator


### PR DESCRIPTION
Email rules:
- Valid University at Buffalo email only
  - User is comprised of letters followed by optional numbers
  - User is 4-8 chars, inclusive
  - Server is (optional subdomain).buffalo.edu
      
Password rules:
- Length between 12 and 255 chars (inclusive)

--------

To run tests:
- `cd` to `./evergreen/`
- run `./manage.py test eg_app/tests/*`