### PR TITLE
Rework Docker & nginx configs to seamlessly handle w/ & w/o SSL cert

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,28 @@
 services:
   database:
     image: postgres:17
-    restart: always #unless-stopped # change to always when in production
+    restart: always
     shm_size: 128mb
-    ports:
-      - "5432:5432"
     env_file: ".env"
 
   django:
     build: ./evergreen
-    ports:
-      - '8080:8080'
+    restart: always
     env_file: ".env"
     volumes:
     - ./media:/root/media
     depends_on:
-      - database 
+      - database
 
   nginx:
     build: ./nginx
+    restart: always
     ports:
       - '80:80'
       - '443:443'
+      - '8080:8080'
     volumes:
       - ./evergreen/staticfiles:/static
       - ./media:/media
+    depends_on:
+      - django

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,6 +1,12 @@
 FROM nginx
 
-COPY ./cert.pem /etc/nginx/cert.pem
-COPY ./private.key /etc/nginx/private.key
+COPY . .
 
-COPY ./default.conf /etc/nginx/conf.d/default.conf
+# Copy SSL cert files, if they exist
+RUN if [ -f ./cert.pem ]; then cp ./cert.pem /etc/nginx/cert.pem; fi
+RUN if [ -f ./private.key ]; then cp ./private.key /etc/nginx/private.key; fi
+
+# Choose whether to use SSL (default) or HTTP-only conf based on above existing
+RUN if [ -f ./cert.pem -a -f ./private.key ]; \
+        then cp ./default.conf /etc/nginx/conf.d/default.conf; \
+        else cp ./no_ssl.conf /etc/nginx/conf.d/default.conf; fi;

--- a/nginx/no_ssl.conf
+++ b/nginx/no_ssl.conf
@@ -1,9 +1,6 @@
 server {
     server_name localhost;
-    listen 443 ssl;
-    
-    ssl_certificate /etc/nginx/cert.pem;
-    ssl_certificate_key /etc/nginx/private.key;
+    listen 80;
 
     location /static/ {
         root /;
@@ -21,13 +18,12 @@ server {
     }
 }
 
-# Upgrade insecure connections to HTTPS
+# Port 8080 is deprecated, redirect to 80
 server {
     server_name localhost;
-    listen 80;
     listen 8080;
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 http://$host:80$request_uri;
     }
 }


### PR DESCRIPTION
Dockerfile will now only try to copy cert files if they exist, and toggle which of two nginx configs to use

Port 8080 is now redirected to relevant default port (80/443)

Plus a couple minor cleanups on related files

Similarly supporting the same steps both local- and server-side is still planned, but I've push it out of scope of this PR for the sake of prioritizing. I'll include that with the GH Action to deploy probably