### PR TITLE
Nuke @csrf_exempt: fix problem instead of symptom

### DIFF
--- a/evergreen/eg_app/views.py
+++ b/evergreen/eg_app/views.py
@@ -16,7 +16,6 @@ from django.http import (
     JsonResponse,
 )
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 
 import eg_app.util.validators as val
 from eg_app.models import Comments, Post
@@ -28,7 +27,6 @@ ROOT_PATH = "/"
 # handles request
 
 
-@csrf_exempt
 def index(request):
     if request.user.is_authenticated:
         return render(
@@ -109,7 +107,6 @@ def addCookies(response: HttpResponse, cookies: dict[str, str]) -> HttpResponse:
     return response
 
 
-@csrf_exempt
 def validate(request):
     if request.method == "POST":
 
@@ -230,7 +227,6 @@ def login_view(request: HttpRequest):
     return HttpResponseBadRequest()
 
 
-@csrf_exempt
 def updateFeed(request) -> JsonResponse:
 
     posts = Post.objects.all().order_by("-timestamp")
@@ -253,7 +249,6 @@ def updateFeed(request) -> JsonResponse:
     return JsonResponse({"posts": posts_data})
 
 
-@csrf_exempt
 def likePost(request, pk) -> JsonResponse:
     user_who_is_liking = request.user
 
@@ -287,7 +282,6 @@ def likePost(request, pk) -> JsonResponse:
     )
 
 
-@csrf_exempt
 def logout_view(request: HttpRequest):
     # Django handles the invalidating and client-side removal of auth tokens itself
     logout(request)

--- a/evergreen/evergreen/settings.py
+++ b/evergreen/evergreen/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = "django-insecure-=mwfbc26f&ixkoi@58!3-_)e#)ega^i4(g*l6h7)405_x-_7nu
 DEBUG = False
 
 ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "*", "https://localhost"]
-CSRF_TRUSTED_ORIGINS = ["https://localhost"]
+CSRF_TRUSTED_ORIGINS = ["http://localhost", "https://localhost"]
 
 
 # Application definition


### PR DESCRIPTION
Just had to add "http://localhost" to Django CSRF_TRUSTED_ORIGINS. That's it.